### PR TITLE
Refactor/response timezone

### DIFF
--- a/src/answer/helper/transform.helper.ts
+++ b/src/answer/helper/transform.helper.ts
@@ -1,5 +1,6 @@
 import { AnswerResponseDto } from '@/survey/dto/answer-response.dto';
 import { Answer } from '@/schema/answer.schema';
+import moment from 'moment-timezone';
 
 export class TransformHelper {
   toArrayResponseDto = (data: Answer[]): AnswerResponseDto[] => {
@@ -8,8 +9,8 @@ export class TransformHelper {
         _id,
         survey,
         author,
-        createdAt,
-        updatedAt,
+        createdAt: moment.utc(createdAt).tz('Asia/Seoul').format(),
+        updatedAt: moment.utc(updatedAt).tz('Asia/Seoul').format(),
         answers,
       }),
     );
@@ -22,8 +23,8 @@ export class TransformHelper {
       _id,
       survey,
       author,
-      createdAt,
-      updatedAt,
+      createdAt: moment.utc(createdAt).tz('Asia/Seoul').format(),
+      updatedAt: moment.utc(updatedAt).tz('Asia/Seoul').format(),
       answers,
     };
   };

--- a/src/schema/answer.schema.ts
+++ b/src/schema/answer.schema.ts
@@ -11,6 +11,7 @@ export class Answer {
 
   @Prop({
     type: Types.ObjectId,
+    ref: 'Survey',
   })
   survey: Types.ObjectId;
 

--- a/src/survey/controller/survey.controller.ts
+++ b/src/survey/controller/survey.controller.ts
@@ -87,7 +87,9 @@ export class SurveyController {
       ],
     },
   })
-  async findPopular(@Query() query: FindPopularSurveyDto) {
+  async findPopular(
+    @Query() query: FindPopularSurveyDto,
+  ): Promise<SurveyResponseDto[] | string[]> {
     return await this.surveyService.findPopular(query);
   }
 

--- a/src/survey/dto/answer-response.dto.ts
+++ b/src/survey/dto/answer-response.dto.ts
@@ -18,14 +18,14 @@ export class AnswerResponseDto {
   author: string;
 
   @ApiProperty({
-    type: Date,
+    type: String,
   })
-  createdAt: Date;
+  createdAt: string;
 
   @ApiProperty({
-    type: Date,
+    type: String,
   })
-  updatedAt: Date;
+  updatedAt: string;
 
   @ApiProperty({
     type: 'array',
@@ -45,8 +45,8 @@ export class AnswerResponseDto {
     _id: Types.ObjectId,
     survey: Types.ObjectId,
     author: string,
-    createdAt: Date,
-    updatedAt: Date,
+    createdAt: string,
+    updatedAt: string,
     answers: [string | number][] | string,
   ) {
     this._id = _id;

--- a/src/survey/dto/survey-response.dto.ts
+++ b/src/survey/dto/survey-response.dto.ts
@@ -41,14 +41,14 @@ export class SurveyResponseDto {
   questions: QuestionResponseDto[] | ABQuestionResponseDto[];
 
   @ApiProperty({
-    type: Date,
+    type: String,
   })
-  createdAt: Date;
+  createdAt: string;
 
   @ApiProperty({
-    type: Date,
+    type: String,
   })
-  updatedAt: Date;
+  updatedAt: string;
 
   @ApiProperty({
     enum: Status,
@@ -66,8 +66,8 @@ export class SurveyResponseDto {
     title: string,
     author: string,
     questions: QuestionResponseDto[] | ABQuestionResponseDto[],
-    createdAt: Date,
-    updatedAt: Date,
+    createdAt: string,
+    updatedAt: string,
     status: Status,
     description?: string,
   ) {

--- a/src/survey/helper/transform.helper.ts
+++ b/src/survey/helper/transform.helper.ts
@@ -1,5 +1,6 @@
 import { SurveyResponseDto } from '@/survey/dto/survey-response.dto';
 import { Survey } from '@/schema/survey.schema';
+import moment from 'moment-timezone';
 
 export class TransformHelper {
   toArrayResponseDto = (data: Survey[]): SurveyResponseDto[] => {
@@ -20,8 +21,8 @@ export class TransformHelper {
         title,
         author,
         questions,
-        createdAt,
-        updatedAt,
+        createdAt: moment.utc(createdAt).tz('Asia/Seoul').format(),
+        updatedAt: moment.utc(updatedAt).tz('Asia/Seoul').format(),
         status,
         description,
       }),
@@ -47,8 +48,8 @@ export class TransformHelper {
       title,
       author,
       questions,
-      createdAt,
-      updatedAt,
+      createdAt: moment.utc(createdAt).tz('Asia/Seoul').format(),
+      updatedAt: moment.utc(updatedAt).tz('Asia/Seoul').format(),
       status,
       description,
     };


### PR DESCRIPTION
closes #24 
- 응답 시에는 UTC -> Asia/Seoul로 time을 반환해서 넘겨주도록 변경했습니다.
  - 기존 responseDto에서는 날짜 관련된 부분이 모두 Date 타입이었는데 Asia/Seoul 타임존을 명시하기 위해 string으로 변경했습니다. 
- 내 응답 내역 조회 부분을 리팩토링 했습니다. (쿼리를 한 번만 날릴 수 있도록)
- Answer Schema에 ref를 추가했습니다.